### PR TITLE
Replace 'Angular' with 'React'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nulogy Engineering TIL Site
-TIL is a public Nulogy microblog for sharing web development tips, tricks, and tidbits. From Ruby on Rails to AngularJS, our Engineering department blogs on topics across the stack to share in our collective success and improve our understanding of all things technology.
+TIL is a public Nulogy microblog for sharing web development tips, tricks, and tidbits. From Ruby on Rails to ReactJS, our Engineering department blogs on topics across the stack to share in our collective success and improve our understanding of all things technology.
 
 # Adding a post
 Simply make a new markdown file in `_posts` folder, follow the recipe established by previous posts. Commit and push to master and you should see the changes at https://nulogy.github.io/til/

--- a/about.md
+++ b/about.md
@@ -4,4 +4,4 @@ title: About
 permalink: /about/
 ---
 
-TIL is a Nulogy microblog for sharing web development tips, tricks, and tidbits. From Ruby on Rails to AngularJS, our Engineering department blogs on topics across the stack to share in our collective success and improve our understanding of all things technology.
+TIL is a Nulogy microblog for sharing web development tips, tricks, and tidbits. From Ruby on Rails to ReactJS, our Engineering department blogs on topics across the stack to share in our collective success and improve our understanding of all things technology.


### PR DESCRIPTION
Nulogy's Engineering department is currently moving away from AngularJS development and more towards ReactJS. Thus, let's update the text in our TIL site to reflect the current state of our business. This is also useful for controlling the company "smell".